### PR TITLE
Some balance and meteorite's spawner enhacement

### DIFF
--- a/Menu_System/Scenes/player.tscn
+++ b/Menu_System/Scenes/player.tscn
@@ -334,6 +334,7 @@ script = ExtResource("1_umu53")
 speed = 400
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+scale = Vector2(0.759999, 1)
 shape = SubResource("CapsuleShape2D_4hh4j")
 
 [node name="hero_mesh" type="Sprite2D" parent="."]

--- a/Menu_System/Scripts/player.gd
+++ b/Menu_System/Scripts/player.gd
@@ -146,7 +146,7 @@ func _on_picked_up_magnification(speed_mul,scale_mul)->void:
 	print("Picked up magnification")
 	
 func _on_picked_up_miniaturization(speed_mul,scale_mul)->void:
-	var _power_up = PowerUp.new(Global.PowerUp.SMALL, 5.0)
+	var _power_up = PowerUp.new(Global.PowerUp.SMALL, 2.0)
 	set_stashed_power_up(_power_up)
 	print("Picked up miniaturization")
 	

--- a/game/levels/level_1_alpha_test.tscn
+++ b/game/levels/level_1_alpha_test.tscn
@@ -39,8 +39,8 @@ win_screen = ExtResource("2_ehymt")
 [node name="Player" parent="." instance=ExtResource("1_gcv57")]
 position = Vector2(54, 81)
 collision_mask = 6
-dash_speed = 1200
-speed = 100
+dash_speed = 50
+speed = 90
 metadata/_edit_group_ = true
 
 [node name="player_camera" type="Camera2D" parent="Player"]
@@ -60,6 +60,18 @@ offset_right = -10.0
 [node name="projectile_spawner" parent="Player" instance=ExtResource("2_bvut5")]
 position = Vector2(50, 0)
 projectile = ExtResource("3_shdic")
+meteortirs_per_second_0 = 2
+meteortirs_per_second_1 = 4
+min_initial_speed_1 = 30.0
+max_initial_speed_1 = 45.0
+meteortirs_per_second_2 = 5
+min_initial_speed_2 = 40.0
+max_initial_speed_2 = 75.0
+meteortirs_per_second_3 = 8
+max_initial_speed_3 = 80.0
+meteortirs_per_second_4 = 12
+min_initial_speed_4 = 50.0
+max_initial_speed_4 = 100.0
 
 [node name="player_sfx" type="AudioStreamPlayer" parent="Player"]
 stream = ExtResource("5_xrsal")
@@ -109,7 +121,7 @@ autoplay = true
 [node name="Areas" type="Node2D" parent="."]
 
 [node name="Threshhold_1_easy" type="Area2D" parent="Areas"]
-position = Vector2(511, 80)
+position = Vector2(500, 80)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Areas/Threshhold_1_easy"]
 shape = SubResource("RectangleShape2D_wauqm")
@@ -121,19 +133,19 @@ position = Vector2(1400, 93)
 shape = SubResource("RectangleShape2D_wauqm")
 
 [node name="Threshhold_3_hard" type="Area2D" parent="Areas"]
-position = Vector2(2110, 90)
+position = Vector2(3000, 90)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Areas/Threshhold_3_hard"]
 shape = SubResource("RectangleShape2D_wauqm")
 
 [node name="Threshhold_4_very_hard" type="Area2D" parent="Areas"]
-position = Vector2(2625, 93)
+position = Vector2(3800, 93)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Areas/Threshhold_4_very_hard"]
 shape = SubResource("RectangleShape2D_wauqm")
 
 [node name="Shelter" type="Area2D" parent="Areas"]
-position = Vector2(3048, 100)
+position = Vector2(4200, 100)
 scale = Vector2(0.113953, -5.43519)
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="Areas/Shelter"]
@@ -157,6 +169,9 @@ metadata/_edit_use_anchors_ = true
 
 [node name="power_ups_spawner" parent="." node_paths=PackedStringArray("Player") instance=ExtResource("8_dyjmd")]
 position = Vector2(0, 81)
+min_spacing = 100
+max_spacing = 200
+spawner_width = 4200
 Player = NodePath("../Player")
 
 [connection signal="unpause" from="Pause Screen" to="." method="_on_pause_screen_unpause"]

--- a/scripts/projectiles/projectile_spawner.gd
+++ b/scripts/projectiles/projectile_spawner.gd
@@ -4,35 +4,42 @@ signal projectile_spawned(pos,init_speed,gravity_scale)
 
 @export var projectile: PackedScene
 
-@export var spawner_width: float = 100
+var spawner_width: float = 100
 var meteortirs_per_second: float  = 1
 ##Default is 9.8.
 var gravity_scale: float = 0.004
 var min_initial_speed: float = 10
 var max_initial_speed: float = 30
 
-##[color=red]Doesn't work.[/color].
+@export var speed_of_fast_prjectile: float = 100;
+var chance_to_spawn_fast_projectile:int = 0
+
 @export_category("difficulty threshholds")
 @export_group("init difficulty")
 @export var meteortirs_per_second_0 = 1
 @export var min_initial_speed_0: float = 10
 @export var max_initial_speed_0: float = 30
+@export_range(0,100) var chance_to_spawn_fast_projectile_0: int = 5
 @export_group("1 difficulty")
 @export var meteortirs_per_second_1 = 1
 @export var min_initial_speed_1: float = 10
 @export var max_initial_speed_1: float = 30
+@export_range(0,100) var chance_to_spawn_fast_projectile_1: int = 15
 @export_group("2 difficulty")
 @export var meteortirs_per_second_2 = 1
 @export var min_initial_speed_2: float = 10
 @export var max_initial_speed_2: float = 30
+@export_range(0,100) var chance_to_spawn_fast_projectile_2: int = 20
 @export_group("3 difficulty")
 @export var meteortirs_per_second_3 = 1
 @export var min_initial_speed_3: float = 10
 @export var max_initial_speed_3: float = 30
+@export_range(0,100) var chance_to_spawn_fast_projectile_3: int = 15
 @export_group("4 difficulty")
 @export var meteortirs_per_second_4 = 1
 @export var min_initial_speed_4: float = 10
 @export var max_initial_speed_4: float = 30
+@export_range(0,100) var chance_to_spawn_fast_projectile_4: int = 10
 
 static var prev_level_of_difficulty: int = 0
 
@@ -44,6 +51,7 @@ func _ready() -> void:
 	meteortirs_per_second = meteortirs_per_second_0
 	min_initial_speed = min_initial_speed_0
 	max_initial_speed = max_initial_speed_0
+	chance_to_spawn_fast_projectile = chance_to_spawn_fast_projectile_0
 	
 func _process(_delta) -> void:
 	pass
@@ -55,29 +63,38 @@ func _exit_tree() -> void:
 	self.queue_free()
 	
 func _on_timer_timeout() -> void:
+	var speed: float = 0
+	if(rand.randi_range(0,100)<chance_to_spawn_fast_projectile):
+		speed = speed_of_fast_prjectile
+	else:
+		speed = rand.randf_range(min_initial_speed,max_initial_speed)
 	emit_signal("projectile_spawned",
 			rand.randf_range(self.global_position.x - spawner_width,spawner_width + self.global_position.x),
-			rand.randf_range(min_initial_speed,max_initial_speed),
+			speed,
 			gravity_scale)
 
 func set_difficulty_level(level: int)->void:
 	if(level == 1 && prev_level_of_difficulty<=level):
-		prev_level_of_difficulty = 1;
-		meteortirs_per_second = meteortirs_per_second_1;
-		min_initial_speed = min_initial_speed_1;
-		max_initial_speed = max_initial_speed_1;
+		prev_level_of_difficulty = 1
+		meteortirs_per_second = meteortirs_per_second_1
+		min_initial_speed = min_initial_speed_1
+		max_initial_speed = max_initial_speed_1
+		chance_to_spawn_fast_projectile = chance_to_spawn_fast_projectile_1
 	elif(level == 2 && prev_level_of_difficulty<=level):
-		prev_level_of_difficulty = 2;
-		meteortirs_per_second = meteortirs_per_second_2;
-		min_initial_speed = min_initial_speed_2;
-		max_initial_speed = max_initial_speed_2;
+		prev_level_of_difficulty = 2
+		meteortirs_per_second = meteortirs_per_second_2
+		min_initial_speed = min_initial_speed_2
+		max_initial_speed = max_initial_speed_2
+		chance_to_spawn_fast_projectile = chance_to_spawn_fast_projectile_2
 	elif(level == 3 && prev_level_of_difficulty<=level):
-		prev_level_of_difficulty = 3;
-		meteortirs_per_second = meteortirs_per_second_3;
-		min_initial_speed = min_initial_speed_3;
-		max_initial_speed = max_initial_speed_3;
+		prev_level_of_difficulty = 3
+		meteortirs_per_second = meteortirs_per_second_3
+		min_initial_speed = min_initial_speed_3
+		max_initial_speed = max_initial_speed_3
+		chance_to_spawn_fast_projectile = chance_to_spawn_fast_projectile_3
 	elif(level == 4 && prev_level_of_difficulty<=level):
-		prev_level_of_difficulty = 4;
-		meteortirs_per_second = meteortirs_per_second_4;
-		min_initial_speed = min_initial_speed_4;
-		max_initial_speed = max_initial_speed_4;
+		prev_level_of_difficulty = 4
+		meteortirs_per_second = meteortirs_per_second_4
+		min_initial_speed = min_initial_speed_4
+		max_initial_speed = max_initial_speed_4
+		chance_to_spawn_fast_projectile = chance_to_spawn_fast_projectile_4


### PR DESCRIPTION
Change time of mini from 5.0 to 2.0
Add possibility to spawn fast meteorites in spawner properties via Inspector (default speed is 100) Collider scaled down toward x for 25%, I feel that way